### PR TITLE
Update to version 2.1.6

### DIFF
--- a/net.labymod.LabyMod.metainfo.xml
+++ b/net.labymod.LabyMod.metainfo.xml
@@ -68,6 +68,19 @@
     <content_attribute id="money-purchasing">intense</content_attribute>
   </content_rating>
   <releases>
+    <release version="2.1.6" date="2024-07-10">
+      <description>
+        <ul>
+          <li>Added Save Selected Patch Setting</li>
+          <li>Added Stop Button to Logs</li>
+          <li>Improved Default Modpack UX when Modloader is selected</li>
+          <li>Fixed Launcher uses the wrong key for the loading addons string</li>
+          <li>Fixed Can't install Fabric loader</li>
+          <li>Fixed Incorrect error notification displayed</li>
+          <li>Fixed News always collapsing after restart</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.1.5" date="2024-06-21">
       <description>
         <ul>

--- a/net.labymod.LabyMod.yml
+++ b/net.labymod.LabyMod.yml
@@ -27,9 +27,9 @@ modules:
     sources:
       - type: extra-data
         filename: laby.deb
-        url: https://releases.r2.labymod.net/launcher/linux/x64/labymodlauncher_2.1.5_amd64.deb
-        sha256: f02b856f3f921b1ad7805f075725bc0669a08d11593c37738fcfa0c697530157
-        size: 89969412
+        url: https://releases.r2.labymod.net/launcher/linux/x64/labymodlauncher_2.1.6_amd64.deb
+        sha256: 75a4d852fc6dbfbf59232bb2c15f38cb7b9052321f38c1291ece50abae8838ed
+        size: 90026140
       - type: file
         path: net.labymod.LabyMod.metainfo.xml
       - type: file
@@ -40,3 +40,4 @@ modules:
         path: apply_extra.sh
       - type: file
         path: net.labymod.LabyMod.desktop
+

--- a/run.sh
+++ b/run.sh
@@ -6,4 +6,4 @@ for i in {0..9}; do
     test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
 done
 
-exec zypak-wrapper /app/extra/launcher/labymodlauncher
+exec zypak-wrapper /app/extra/launcher/labymodlauncher --no-update-check


### PR DESCRIPTION
Added additionally that no update notes are displayed in the Flatpak version of LabyMod.